### PR TITLE
Onboarding setup

### DIFF
--- a/src/main/app_config_store.ts
+++ b/src/main/app_config_store.ts
@@ -9,6 +9,7 @@ const log = electronLog.scope('app-config-store')
 
 const CURRENT_VIEW_ID_KEY = 'CURRENT_VIEW_ID'
 const START_ON_LOGIN_KEY = 'START_ON_LOGIN'
+const FIRST_RUN_KEY = 'FIRST_RUN'
 
 export class AppConfigStore {
     private static store = new Store()
@@ -33,5 +34,16 @@ export class AppConfigStore {
     public static set startOnLogin(value: boolean | undefined) {
         log.debug('Setting start on login to:', value)
         AppConfigStore.store.set(START_ON_LOGIN_KEY, value)
+    }
+
+    public static get firstRun(): boolean {
+        const firstRun = AppConfigStore.store.get(FIRST_RUN_KEY) as boolean | undefined
+        log.debug('First run retrieved:', firstRun)
+        return firstRun ?? true
+    }
+
+    public static set firstRun(value: boolean) {
+        log.debug('Setting first run to:', value)
+        AppConfigStore.store.set(FIRST_RUN_KEY, value)
     }
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -241,6 +241,15 @@ mb.on('ready', () => {
         })
     }
 
+    // If first run, show user the window
+    if (AppConfigStore.firstRun) {
+        mb.showWindow()
+        // If macOS, no onboarding, so first run must be reset here
+        if (process.platform === 'darwin') {
+            AppConfigStore.firstRun = false
+        }
+    }
+
     // Run an update on start
     WallpaperManager.update(Initiator.user)
 })

--- a/src/renderer/components/Main.tsx
+++ b/src/renderer/components/Main.tsx
@@ -65,7 +65,7 @@ interface WindowsOnboardingDialogProps {
 }
 
 const WindowsOnboardingDialog: React.FC<WindowsOnboardingDialogProps> = props => (
-    <Dialog open={props.show}>
+    <Dialog open={props.show} style={{ userSelect: 'none' }}>
         <DialogTitle>Welcome to SpaceEye!</DialogTitle>
         <DialogContent>
             <DialogContentText>
@@ -73,7 +73,7 @@ const WindowsOnboardingDialog: React.FC<WindowsOnboardingDialogProps> = props =>
                 and select &quot;Show icon and notifications&quot; for &quot;SpaceEye&quot;.
             </DialogContentText>
             <DialogContentText>
-                You can do this later by Windows Searching for &quot;Select which icons appear on
+                You can do this later by Windows searching for &quot;Select which icons appear on
                 the taskbar&quot;
             </DialogContentText>
         </DialogContent>

--- a/src/renderer/components/Main.tsx
+++ b/src/renderer/components/Main.tsx
@@ -1,10 +1,28 @@
 import 'fontsource-roboto'
 
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle
+} from '@material-ui/core'
 import { createMuiTheme, ThemeProvider as MuiThemeProvider } from '@material-ui/core/styles'
 import * as React from 'react'
 import { HashRouter, Route } from 'react-router-dom'
 import styled, { ThemeProvider } from 'styled-components'
 
+import {
+    GET_FIRST_RUN,
+    GetFirstRunIpcResponse,
+    IpcParams,
+    IpcResponse,
+    OPEN_WINDOWS_ICON_SETTINGS,
+    SET_FIRST_RUN,
+    SetFirstRunIpcParams
+} from '../../shared/IpcDefinitions'
+import { ipcRequest } from '../IpcService'
 import { DarkTheme } from '../themes'
 import HeaderBar from './HeaderBar'
 import Settings from './Settings'
@@ -40,13 +58,76 @@ const theme = createMuiTheme({
     }
 })
 
-const ImagePickerPage: React.FC = () => (
-    <Container>
-        <HeaderBar />
-        <ThumbnailManager />
-        {/* <Toolbar /> */}
-    </Container>
+interface WindowsOnboardingDialogProps {
+    show: boolean
+    onDone: () => void
+    onOpenSettings: () => void
+}
+
+const WindowsOnboardingDialog: React.FC<WindowsOnboardingDialogProps> = props => (
+    <Dialog open={props.show}>
+        <DialogTitle>Welcome to SpaceEye!</DialogTitle>
+        <DialogContent>
+            <DialogContentText>
+                To make sure the app icon is always visible in your taskbar, click the button below
+                and select &quot;Show icon and notifications&quot; for &quot;SpaceEye&quot;.
+            </DialogContentText>
+            <DialogContentText>
+                You can do this later by Windows Searching for &quot;Select which icons appear on
+                the taskbar&quot;
+            </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+            <Button onClick={props.onDone}>Done</Button>
+            <Button color="primary" onClick={props.onOpenSettings}>
+                Open Icon Settings
+            </Button>
+        </DialogActions>
+    </Dialog>
 )
+
+export interface ImagePickerPageState {
+    isOnboarding: boolean
+}
+
+class ImagePickerPage extends React.Component<{}, ImagePickerPageState> {
+    constructor(props: {}) {
+        super(props)
+
+        this.state = {
+            isOnboarding: false
+        }
+
+        this.finishOnboarding = this.finishOnboarding.bind(this)
+    }
+
+    async componentDidMount() {
+        // Check if we need to onboard the user
+        const res = await ipcRequest<IpcParams, GetFirstRunIpcResponse>(GET_FIRST_RUN, {})
+        this.setState({ isOnboarding: res.firstRun })
+    }
+
+    finishOnboarding() {
+        this.setState({ isOnboarding: false })
+        // No longer a first run after the user dismisses the message
+        ipcRequest<SetFirstRunIpcParams, IpcResponse>(SET_FIRST_RUN, { firstRun: false }, false)
+    }
+
+    public render() {
+        return (
+            <Container>
+                <HeaderBar />
+                <ThumbnailManager />
+                {/* <Toolbar /> */}
+                <WindowsOnboardingDialog
+                    show={this.state.isOnboarding && process.platform === 'win32'}
+                    onDone={this.finishOnboarding}
+                    onOpenSettings={() => ipcRequest(OPEN_WINDOWS_ICON_SETTINGS, {}, false)}
+                />
+            </Container>
+        )
+    }
+}
 
 /**
  *

--- a/src/shared/IpcDefinitions.ts
+++ b/src/shared/IpcDefinitions.ts
@@ -54,6 +54,14 @@ export interface SetStartOnLoginIpcParams {
     startOnLogin: boolean
 }
 
+export interface GetFirstRunIpcResponse {
+    firstRun: boolean
+}
+
+export interface SetFirstRunIpcParams {
+    firstRun: boolean
+}
+
 export const EXAMPLE_CHANNEL = 'EXAMPLE_CHANNEL'
 export const GET_SATELLITE_CONFIG_CHANNEL = 'GET_SATELLITE_CONFIG_CHANNEL'
 export const SET_WALLPAPER_CHANNEL = 'SET_WALLPAPER_CHANNEL'
@@ -62,3 +70,6 @@ export const GET_CURRENT_VIEW_CHANNEL = 'GET_CURRENT_VIEW_CHANNEL'
 export const DOWNLOAD_THUMBNAIL_CHANNEL = 'DOWNLOAD_THUMBNAIL_CHANNEL'
 export const GET_START_ON_LOGIN = 'GET_START_ON_LOGIN'
 export const SET_START_ON_LOGIN = 'SET_START_ON_LOGIN'
+export const GET_FIRST_RUN = 'GET_FIRST_RUN'
+export const SET_FIRST_RUN = 'SET_FIRST_RUN'
+export const OPEN_WINDOWS_ICON_SETTINGS = 'OPEN_WINDOWS_ICON_SETTINGS'


### PR DESCRIPTION
Implemented an on-boarding dialog for Windows

- Tells the user how to make the icon persist in their taskbar.
  - Button will open the settings for them.
- Also implemented a "first run" setting so on-boarding tasks can be performed the first time the user opens the app.
- Window also automatically opens on first run.