### PR TITLE
Fix npm dev issues

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -21,13 +21,13 @@ mac:
   extendInfo:
     LSUIElement: true
   publish: [github]
-  icon: node_modules/@kydronepilot/space-eye-icons/dist/mac_app.icns
+  icon: node_modules/space-eye-icons/dist/mac_app.icns
 win:
   target:
     - target: nsis
       arch: x64
   publish: [github]
-  icon: node_modules/@kydronepilot/space-eye-icons/dist/windows_app.ico
+  icon: node_modules/space-eye-icons/dist/windows_app.ico
 mas:
   type: distribution
   entitlements: build/entitlements.mas.plist

--- a/package.json
+++ b/package.json
@@ -139,6 +139,8 @@
         "react-dom": "^16.8.6",
         "react-router-dom": "^5.2.0",
         "simplebar-react": "^2.2.0",
+        "space-eye-mac-node-api": "^1.0.0-beta2",
+        "space-eye-windows-node-api": "^1.0.0-beta1",
         "styled-components": "^5.1.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -139,8 +139,8 @@
         "react-dom": "^16.8.6",
         "react-router-dom": "^5.2.0",
         "simplebar-react": "^2.2.0",
-        "space-eye-mac-node-api": "^1.0.0-beta2",
-        "space-eye-windows-node-api": "^1.0.0-beta1",
+        "space-eye-mac-node-api": "^1.0.2",
+        "space-eye-windows-node-api": "^1.0.3",
         "styled-components": "^5.1.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
         "webpack-merge": "^4.2.1"
     },
     "dependencies": {
-        "@kydronepilot/space-eye-icons": "^0.2.3",
         "@material-ui/core": "^4.11.0",
         "@material-ui/icons": "^4.9.1",
         "async-lock": "^1.2.4",
@@ -139,6 +138,7 @@
         "react-dom": "^16.8.6",
         "react-router-dom": "^5.2.0",
         "simplebar-react": "^2.2.0",
+        "space-eye-icons": "^0.3.0",
         "space-eye-mac-node-api": "^1.0.2",
         "space-eye-windows-node-api": "^1.0.3",
         "styled-components": "^5.1.0"

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import infoIcon from '@kydronepilot/space-eye-icons/dist/info_app.png'
 import {
     Box,
     Button,
@@ -19,6 +18,7 @@ import { ipcRenderer as ipc } from 'electron-better-ipc'
 import path from 'path'
 import * as React from 'react'
 import { Redirect } from 'react-router-dom'
+import infoIcon from 'space-eye-icons/dist/info_app.png'
 import styled from 'styled-components'
 
 import {

--- a/webpack.main.config.js
+++ b/webpack.main.config.js
@@ -43,7 +43,7 @@ module.exports = merge.smart(baseConfig, {
         new CopyPlugin({
             patterns: [
                 {
-                    from: 'node_modules/@kydronepilot/space-eye-icons/dist',
+                    from: 'node_modules/space-eye-icons/dist',
                     to: 'icons'
                 }
             ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1293,11 +1293,6 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@kydronepilot/space-eye-icons@^0.2.3":
-  version "0.2.3"
-  resolved "https://npm.pkg.github.com/download/@kydronepilot/space-eye-icons/0.2.3/f45742b1ea1a97c3fa7036303f50433a39f2a329e88b8de1cc1e25c5bf8e50d9#f7453856be1abfc2d815afb8fe292e52f6d44f2c"
-  integrity sha512-/T+dV5zcPm0bjy0xtvO0oxu24B9fFXhfa/2TlrYlk/Cg/TOyybvvtnnqRIxpiRAQOB+VWH/cH8xb5GBYV4/R9w==
-
 "@material-ui/core@^4.11.0":
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.0.tgz#b69b26e4553c9e53f2bfaf1053e216a0af9be15a"
@@ -12192,6 +12187,11 @@ source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+space-eye-icons@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/space-eye-icons/-/space-eye-icons-0.3.0.tgz#6006a45aac5856d1d65c9a5397c9056e6ba07db6"
+  integrity sha512-ahcPfukQpFVnghgmD65rCRx8CVTmOaWAxlaG6QofFb7fRDlVxYaJW4VwyHS4v4uKFaUbaqgxgzCeUrP9Z1WH9A==
 
 space-eye-mac-node-api@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12193,17 +12193,17 @@ source-map@^0.7.3:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-space-eye-mac-node-api@^1.0.0-beta2:
-  version "1.0.0-beta2"
-  resolved "https://registry.yarnpkg.com/space-eye-mac-node-api/-/space-eye-mac-node-api-1.0.0-beta2.tgz#b9a5e9f758bb0ea5a12bdf42b176d23adbff0d38"
-  integrity sha512-9HTx6z+9d/wCHKIxfudoDCE6TbqBVywWUpzbFUfUp6civ5qgwdOl46hPHP/YXb3IV9mCU2bsL3bx+MZGJDRrvQ==
+space-eye-mac-node-api@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/space-eye-mac-node-api/-/space-eye-mac-node-api-1.0.2.tgz#4ea7dc0d02cb3788c1bcf604c70c5f912e5fff59"
+  integrity sha512-xgUTvgI+UVRxKnBMbZzoqeYlI/hNjiN34f2QSO1gslvqMdVpVxNJd0NL85gutKDNwXOSY9FjRNOba0uERjlXRw==
   dependencies:
     node-addon-api "^3.0.0"
 
-space-eye-windows-node-api@^1.0.0-beta1:
-  version "1.0.0-beta1"
-  resolved "https://registry.yarnpkg.com/space-eye-windows-node-api/-/space-eye-windows-node-api-1.0.0-beta1.tgz#9de82b472c74aeff53b9400af7aa33ae8106aeef"
-  integrity sha512-nUTHzWbLvK9DhR42PgAmicEwgUMUt22K/GnozSMglDpy2Qvc4KH8+jzbjFEEwYVHZsxYnsrzBSAeUtZQ17TvbQ==
+space-eye-windows-node-api@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/space-eye-windows-node-api/-/space-eye-windows-node-api-1.0.3.tgz#bb8c64a46d411273a72c81f2499f120129fb4eee"
+  integrity sha512-0zyEK7TrLx9yFFRMgLijlxTejyLYW1hiIKiRXrDYurlbhgL9yevutw2rWuhbk1h6n01uCO1giDbHuNvbuEa/yQ==
   dependencies:
     node-addon-api "^3.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9587,6 +9587,11 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
+node-addon-api@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.1.0.tgz#98b21931557466c6729e51cb77cd39c965f42239"
+  integrity sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==
+
 node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
@@ -12187,6 +12192,20 @@ source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+space-eye-mac-node-api@^1.0.0-beta2:
+  version "1.0.0-beta2"
+  resolved "https://registry.yarnpkg.com/space-eye-mac-node-api/-/space-eye-mac-node-api-1.0.0-beta2.tgz#b9a5e9f758bb0ea5a12bdf42b176d23adbff0d38"
+  integrity sha512-9HTx6z+9d/wCHKIxfudoDCE6TbqBVywWUpzbFUfUp6civ5qgwdOl46hPHP/YXb3IV9mCU2bsL3bx+MZGJDRrvQ==
+  dependencies:
+    node-addon-api "^3.0.0"
+
+space-eye-windows-node-api@^1.0.0-beta1:
+  version "1.0.0-beta1"
+  resolved "https://registry.yarnpkg.com/space-eye-windows-node-api/-/space-eye-windows-node-api-1.0.0-beta1.tgz#9de82b472c74aeff53b9400af7aa33ae8106aeef"
+  integrity sha512-nUTHzWbLvK9DhR42PgAmicEwgUMUt22K/GnozSMglDpy2Qvc4KH8+jzbjFEEwYVHZsxYnsrzBSAeUtZQ17TvbQ==
+  dependencies:
+    node-addon-api "^3.0.0"
 
 sparkles@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
- Created prebuilt packages of Mac and Windows APIs so both packages could be listed as dependencies regardless of platform.
- Moved `space-eye-icons` to [npmjs.com](npmjs.com) so devs won't need GitHub tokens to install it.